### PR TITLE
「#5 既存機能のリファクタリング」planIdをグローバルステートで管理

### DIFF
--- a/src/app/(web)/plan/[planId]/input/airport/page.tsx
+++ b/src/app/(web)/plan/[planId]/input/airport/page.tsx
@@ -1,14 +1,6 @@
 import { InputHeader } from "@/features/plan/input";
 
-export default async function AirportInputPage({
-  params,
-}: {
-  params: Promise<{
-    planId: string;
-  }>;
-}) {
-  const { planId } = await params;
-
+export default function AirportInputPage() {
   return (
     <div className="flex flex-col gap-4">
       <InputHeader

--- a/src/app/(web)/plan/[planId]/input/analytics/page.tsx
+++ b/src/app/(web)/plan/[planId]/input/analytics/page.tsx
@@ -1,21 +1,14 @@
 import { InputHeader } from "@/features/plan/input";
 import { AnalyticsInputContainer } from "@/features/plan/input/analytics";
 
-export default async function AnalyticsPage({
-  params,
-}: {
-  params: Promise<{
-    planId: string;
-  }>;
-}) {
-  const { planId } = await params;
+export default async function AnalyticsPage() {
   return (
     <div className="flex flex-col gap-8">
       <InputHeader
         title="運航計画のための分析データ"
         description="外部データ分析協力会社へデータを依頼"
       />
-      <AnalyticsInputContainer planId={planId} />
+      <AnalyticsInputContainer />
     </div>
   );
 }

--- a/src/app/(web)/plan/[planId]/input/layout.tsx
+++ b/src/app/(web)/plan/[planId]/input/layout.tsx
@@ -1,18 +1,13 @@
 import { BreadcrumbSection } from "@/features/plan/input";
 
-export default async function InputLayout({
+export default function InputLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: Promise<{
-    planId: string;
-  }>;
 }) {
-  const { planId } = await params;
   return (
     <div className="flex flex-col w-full h-full">
-      <BreadcrumbSection planId={planId} />
+      <BreadcrumbSection />
       {children}
     </div>
   );

--- a/src/app/(web)/plan/[planId]/input/page.tsx
+++ b/src/app/(web)/plan/[planId]/input/page.tsx
@@ -2,15 +2,7 @@ import { SquareButton } from "@/components/button";
 import { PointCard } from "@/components/card";
 import { InputCategoriesSection } from "@/features/plan/input";
 
-export default async function PlanInputPage({
-  params,
-}: {
-  params: Promise<{
-    planId: string;
-  }>;
-}) {
-  const { planId } = await params;
-
+export default function PlanInputPage() {
   return (
     <div className="flex flex-col gap-8 pb-16">
       <PointCard color="primary" onPointBorder>
@@ -28,7 +20,7 @@ export default async function PlanInputPage({
         </div>
       </PointCard>
 
-      <InputCategoriesSection planId={planId} />
+      <InputCategoriesSection />
 
       <div className="flex justify-end">
         <SquareButton text="結果を算出" bold size="lg" />

--- a/src/app/(web)/plan/[planId]/input/resource/page.tsx
+++ b/src/app/(web)/plan/[planId]/input/resource/page.tsx
@@ -1,21 +1,14 @@
 import { InputHeader } from "@/features/plan/input";
 import { ResourceInputContainer } from "@/features/plan/input/resource";
 
-export default async function ResourcePage({
-  params,
-}: {
-  params: Promise<{
-    planId: string;
-  }>;
-}) {
-  const { planId } = await params;
+export default function ResourcePage() {
   return (
     <div className="flex flex-col gap-8">
       <InputHeader
         title="自社資源データ"
         description="運航本部総括部・財務部へデータを依頼"
       />
-      <ResourceInputContainer planId={planId} />
+      <ResourceInputContainer />
     </div>
   );
 }

--- a/src/app/(web)/plan/[planId]/layout.tsx
+++ b/src/app/(web)/plan/[planId]/layout.tsx
@@ -13,7 +13,7 @@ export default async function PlanLayout({
   return (
     <div className="flex flex-col gap-12 w-[90%] max-w-[1200px] h-[90%]">
       <AccessWrapper planId={planId}>
-        <HeaderWrapper planId={planId}>{children}</HeaderWrapper>
+        <HeaderWrapper>{children}</HeaderWrapper>
       </AccessWrapper>
     </div>
   );

--- a/src/features/plan/base/view/editTitle/hooks/useEditTitle.ts
+++ b/src/features/plan/base/view/editTitle/hooks/useEditTitle.ts
@@ -3,6 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToastStore } from "@/features/toast";
 import { useModalStore } from "@/features/modal";
+import { usePlanId } from "@/features/plan/stores/planStore";
 import {
   type EditTitleFormData,
   editTitleFormSchema,
@@ -12,12 +13,11 @@ import camelcaseKeys from "camelcase-keys";
 import { apiFetchJson } from "@/lib/api";
 
 export default function useEditTitle({
-  planId,
   defaultValue: { title } = { title: "" },
 }: {
-  planId: string;
   defaultValue: EditTitleFormData;
 }) {
+  const planId = usePlanId();
   const formMethods = useForm<EditTitleFormData>({
     mode: "onChange",
     resolver: zodResolver(editTitleFormSchema),

--- a/src/features/plan/base/view/editTitle/widgets/modal.tsx
+++ b/src/features/plan/base/view/editTitle/widgets/modal.tsx
@@ -9,14 +9,11 @@ import EditTitleForm from "./form";
 import { type EditTitleFormData } from "../schemas/editTitleFormSchema";
 
 export default function EditTitleModal({
-  planId,
   defaultValue: { title } = { title: "" },
 }: {
-  planId: string;
   defaultValue: EditTitleFormData;
 }) {
   const { formMethods, onSubmit, isPending } = useEditTitle({
-    planId,
     defaultValue: { title },
   });
   const { closeModal } = useModalStore();

--- a/src/features/plan/base/view/hooks/useGetPlan.ts
+++ b/src/features/plan/base/view/hooks/useGetPlan.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
+import usePlanStore from "@/features/plan/stores/planStore";
 import { PlanSchema } from "../../server/schemas/common.schema";
 import camelcaseKeys from "camelcase-keys";
 import { apiFetchJson } from "@/lib/api";
 
-export default function useGetPlan(planId: string) {
+export default function useGetPlan() {
+  const { planId } = usePlanStore();
+
   const { data: plan = null, isFetching } = useQuery({
     queryKey: ["plan", planId],
-    queryFn: () => getPlanAPI(planId),
+    queryFn: () => getPlanAPI(planId!),
     enabled: !!planId,
     staleTime: 60 * 60 * 1000, // 1時間
   });

--- a/src/features/plan/base/view/widgets/accessWrapper.tsx
+++ b/src/features/plan/base/view/widgets/accessWrapper.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useUserStore } from "@/features/auth";
+import usePlanStore from "@/features/plan/stores/planStore";
 import { useGetParticipants } from "@/features/plan/participant";
 import { useToastStore } from "@/features/toast";
 import { DoubleSpinner } from "@/components/spinner";
@@ -15,7 +16,12 @@ export default function AccessWrapper({
   planId: string;
   children: React.ReactNode;
 }) {
-  const { participants } = useGetParticipants(planId);
+  const { setPlanId } = usePlanStore();
+  useEffect(() => {
+    setPlanId(planId);
+  }, []);
+
+  const { participants } = useGetParticipants();
   const { user } = useUserStore();
 
   const hasAccess: boolean | undefined = useMemo(() => {

--- a/src/features/plan/base/view/widgets/headerWrapper.tsx
+++ b/src/features/plan/base/view/widgets/headerWrapper.tsx
@@ -11,14 +11,12 @@ import { ParticipantButton } from "@/features/plan/participant";
 import { dateToYearMonthJP } from "@/lib/utils";
 
 export default function HeaderWrapper({
-  planId,
   children,
 }: {
-  planId: string;
   children: React.ReactNode;
 }) {
   const { user } = useUserStore();
-  const { plan } = useGetPlan(planId);
+  const { plan } = useGetPlan();
 
   const pathname = usePathname();
   const isInputSubPage = ["/resource", "/analytics", "/airport"].some(
@@ -54,7 +52,6 @@ export default function HeaderWrapper({
                   <EditButton
                     onClick={() =>
                       openModal("editTitle", {
-                        planId,
                         defaultValue: { title: plan.title },
                       })
                     }
@@ -66,7 +63,7 @@ export default function HeaderWrapper({
                   対象期間: {dateToYearMonthJP(new Date(plan.targetDate))}
                 </p>
                 <ParticipantButton
-                  onClick={() => openModal("participantView", { planId })}
+                  onClick={() => openModal("participantView")}
                 />
               </div>
             </div>

--- a/src/features/plan/input/analytics/widgets/analyticsInputContainer.tsx
+++ b/src/features/plan/input/analytics/widgets/analyticsInputContainer.tsx
@@ -10,9 +10,9 @@ import { Spinner } from "@/components/spinner";
 import { INPUT_DATA_DETAIL_LABELS, INPUT_DATA_LABELS } from "../../constant";
 import InputContainer from "../../widgets/inputContainer";
 
-export default function ResourceInputContainer({ planId }: { planId: string }) {
+export default function ResourceInputContainer() {
   const { openModal } = useModalStore();
-  const { planInputStatus } = useGetPlanInputStatus(planId);
+  const { planInputStatus } = useGetPlanInputStatus();
 
   const inputItems = useMemo(() => {
     if (!planInputStatus) return [];

--- a/src/features/plan/input/resource/widgets/resourceInputContainer.tsx
+++ b/src/features/plan/input/resource/widgets/resourceInputContainer.tsx
@@ -10,9 +10,9 @@ import { Spinner } from "@/components/spinner";
 import { INPUT_DATA_DETAIL_LABELS, INPUT_DATA_LABELS } from "../../constant";
 import InputContainer from "../../widgets/inputContainer";
 
-export default function ResourceInputContainer({ planId }: { planId: string }) {
+export default function ResourceInputContainer() {
   const { openModal } = useModalStore();
-  const { planInputStatus } = useGetPlanInputStatus(planId);
+  const { planInputStatus } = useGetPlanInputStatus();
 
   const inputItems = useMemo(() => {
     if (!planInputStatus) return [];

--- a/src/features/plan/input/types.ts
+++ b/src/features/plan/input/types.ts
@@ -1,4 +1,3 @@
 export interface InputModalProps {
-  planId?: string;
   type?: "view" | "edit";
 }

--- a/src/features/plan/input/widgets/breadcrumbSection.tsx
+++ b/src/features/plan/input/widgets/breadcrumbSection.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { usePlanId } from "@/features/plan/stores/planStore";
 import { useGetPlan } from "@/features/plan/base/view";
 import Breadcrumb from "../components/breadcrumb";
 import { INPUT_CATEGORY_LABELS } from "@/features/plan/input/constant";
 
-export default function BreadcrumbSection({ planId }: { planId: string }) {
-  const { plan } = useGetPlan(planId);
+export default function BreadcrumbSection() {
+  const planId = usePlanId();
+  const { plan } = useGetPlan();
 
   // TODO : 나중에 외부 입력자일 때는 BreadCrumb 안 보이도록
   const pathname = usePathname();

--- a/src/features/plan/input/widgets/inputCategoriesSection.tsx
+++ b/src/features/plan/input/widgets/inputCategoriesSection.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { usePlanId } from "@/features/plan/stores/planStore";
 import { Spinner } from "@/components/spinner";
 import InputCategoryCard from "../components/inputCategoryCard";
 import {
@@ -12,9 +13,10 @@ import {
 import { getOverallStatus } from "@/features/plan/status/utils";
 import { INPUT_CATEGORY_LABELS } from "@/features/plan/input/constant";
 
-export default function InputCategoriesSection({ planId }: { planId: string }) {
+export default function InputCategoriesSection() {
+  const planId = usePlanId();
   const router = useRouter();
-  const { planInputStatus } = useGetPlanInputStatus(planId);
+  const { planInputStatus } = useGetPlanInputStatus();
 
   const statuses = useMemo(() => {
     if (!planInputStatus) return undefined;

--- a/src/features/plan/participant/form/hooks/useEditParticipant.ts
+++ b/src/features/plan/participant/form/hooks/useEditParticipant.ts
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToastStore } from "@/features/toast";
 import { useModalStore } from "@/features/modal";
+import { usePlanId } from "@/features/plan/stores/planStore";
 import {
   editParticipantsFormSchema,
   type EditParticipantsFormSchema,
@@ -15,12 +16,11 @@ import camelcaseKeys from "camelcase-keys";
 import { apiFetchJson } from "@/lib/api";
 
 export default function useEditParticipant({
-  planId,
   defaultValue,
 }: {
-  planId: string;
   defaultValue: EditParticipantsFormSchema;
 }) {
+  const planId = usePlanId();
   const formMethods = useForm<EditParticipantsFormSchema>({
     mode: "onChange",
     resolver: zodResolver(editParticipantsFormSchema),
@@ -43,7 +43,7 @@ export default function useEditParticipant({
       queryClient.invalidateQueries({
         queryKey: ["plan", planId, "participants"],
       });
-      openModal("participantView", { planId });
+      openModal("participantView");
     },
     onError: (error) => {
       addToast({

--- a/src/features/plan/participant/form/widgets/modal.tsx
+++ b/src/features/plan/participant/form/widgets/modal.tsx
@@ -9,14 +9,11 @@ import ParticipantsField from "./field";
 import { type EditParticipantsFormSchema } from "../schemas/form.schema";
 
 export default function ParticipantsEditModal({
-  planId,
   defaultValue,
 }: {
-  planId: string;
   defaultValue: EditParticipantsFormSchema;
 }) {
   const { formMethods, onSubmit, isPending } = useEditParticipant({
-    planId,
     defaultValue,
   });
   const { closeModal, openModal } = useModalStore();
@@ -32,7 +29,7 @@ export default function ParticipantsEditModal({
           cancelProps={{
             text: "キャンセル",
             color: "light-gray",
-            onClick: () => openModal("participantView", { planId }),
+            onClick: () => openModal("participantView"),
             disabled: isPending,
           }}
           confirmProps={{

--- a/src/features/plan/participant/view/hooks/useGetParticipants.ts
+++ b/src/features/plan/participant/view/hooks/useGetParticipants.ts
@@ -1,14 +1,17 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import usePlanStore from "@/features/plan/stores/planStore";
 import { type GetPlanParticipantsResSchema } from "../../servers/schemas/res.schema";
 import camelcaseKeys from "camelcase-keys";
 import { apiFetchJson } from "@/lib/api";
 
-export default function useGetParticipants(planId: string) {
+export default function useGetParticipants() {
+  const { planId } = usePlanStore();
+
   const { data: participants = null, isFetching } = useQuery({
     queryKey: ["plan", planId, "participants"],
-    queryFn: () => getParticipantsAPI(planId),
+    queryFn: () => getParticipantsAPI(planId!),
     enabled: !!planId,
     staleTime: 60 * 60 * 1000, // 1時間
   });

--- a/src/features/plan/participant/view/widgets/modal.tsx
+++ b/src/features/plan/participant/view/widgets/modal.tsx
@@ -9,11 +9,11 @@ import { PointCard } from "@/components/card";
 import SelectedParticipantDetail from "../../components/selectedParticipantDetail";
 import { Spinner } from "@/components/spinner";
 
-export default function ParticipantViewModal({ planId }: { planId: string }) {
+export default function ParticipantViewModal() {
   const { openModal, closeModal } = useModalStore();
 
   const { user } = useUserStore();
-  const { participants, isFetching } = useGetParticipants(planId);
+  const { participants, isFetching } = useGetParticipants();
   const isCreator = participants!.creator.userId === user!.userId;
   const participantDataList = participants!.participantDataList;
 
@@ -82,7 +82,6 @@ export default function ParticipantViewModal({ planId }: { planId: string }) {
                     ),
                   };
                   openModal("participantsEdit", {
-                    planId,
                     defaultValue: editFormDefaultValue,
                   });
                 },

--- a/src/features/plan/status/hooks/useGetPlanInputStatus.ts
+++ b/src/features/plan/status/hooks/useGetPlanInputStatus.ts
@@ -1,12 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
+import usePlanStore from "@/features/plan/stores/planStore";
 import { type GetPlanInputsStatusResSchema } from "../server/schemas/res.schema";
 import camelcaseKeys from "camelcase-keys";
 import { apiFetchJson } from "@/lib/api";
 
-export default function useGetPlanInputStatus(planId: string) {
+export default function useGetPlanInputStatus() {
+  const { planId } = usePlanStore();
+
   const { data: planInputStatus = null, isFetching } = useQuery({
     queryKey: ["plan", planId, "status", "input"],
-    queryFn: () => getPlanInputStatusAPI(planId),
+    queryFn: () => getPlanInputStatusAPI(planId!),
     enabled: !!planId,
     staleTime: 60 * 60 * 1000, // 1時間
   });

--- a/src/features/plan/stores/planStore.ts
+++ b/src/features/plan/stores/planStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+interface PlanStore {
+  planId: string | null;
+  setPlanId: (planId: string) => void;
+}
+
+const usePlanStore = create<PlanStore>((set) => ({
+  planId: null,
+  setPlanId: (planId: string) => set({ planId }),
+}));
+
+export const usePlanId = () =>
+  usePlanStore((s) => {
+    if (s.planId == null) {
+      throw new Error("planId is not set");
+    }
+    return s.planId;
+  });
+
+export default usePlanStore;


### PR DESCRIPTION
Issue #5 
- `props driling`で渡していた `planId` をグローバルステートで管理